### PR TITLE
Add backend switching to B_calculus with numpy fallback

### DIFF
--- a/engine/math/b_calculus.py
+++ b/engine/math/b_calculus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 b_calculus.py
 
@@ -7,36 +9,91 @@ based on your formal definitions.
 Author: ME aka "U" the author, innovator, engineer and scientist (concept) + ChatGPT (implementation)
 """
 
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
 import numpy as np
-import torch
+
+from engine.backends import select_backend
+from engine.backends.backends_numpy import NumpyBackend
+
+if find_spec("torch") is not None:
+    from engine.backends.backends_torch import TorchBackend
+else:  # pragma: no cover - torch is optional
+    TorchBackend = None  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    import torch
+
+NUMPY_BACKEND = NumpyBackend()
+TORCH_BACKEND = TorchBackend() if TorchBackend is not None else None
+
+BACKEND_NAME, xp = select_backend()
+
+if BACKEND_NAME == "torch" and TORCH_BACKEND is not None:
+    TORCH_BACKEND = xp
+elif BACKEND_NAME == "numpy":
+    NUMPY_BACKEND = xp
+
+
+def _backend(backend=None):
+    if backend is None:
+        return xp
+    if isinstance(backend, str):
+        name = backend.lower()
+        if name == "numpy":
+            return NUMPY_BACKEND
+        if name == "torch":
+            if TORCH_BACKEND is None:
+                raise ImportError("Torch backend requested but torch is not installed.")
+            return TORCH_BACKEND
+        raise ValueError(f"Unknown backend string: {backend}")
+    return backend
+
+
+def set_backend(backend=None):
+    """Override the module-level backend.
+
+    ``backend`` can be a backend instance, ``"numpy"``, or ``"torch"``.
+    Returns the backend that is set.
+    """
+
+    global xp, BACKEND_NAME
+    be = _backend(backend)
+    xp = be
+    BACKEND_NAME = "torch" if (TORCH_BACKEND is not None and be is TORCH_BACKEND) else "numpy"
+    return be
+
+
+def _as_backend_array(x, backend=None):
+    be = _backend(backend)
+    return be.asarray(x)
 
 # ============================================================
 #  B-ARITHMETIC (Fundamental Operations)
 # ============================================================
 
-def b_add(x, y):
+def b_add(x, y, backend=None):
     """B-addition: x ⊕ y = x * y"""
-    return x * y
+    be = _backend(backend)
+    return be.b_add(_as_backend_array(x, be), _as_backend_array(y, be))
 
 
-def b_sub(x, y):
+def b_sub(x, y, backend=None):
     """B-subtraction: x ⊖ y = x / y"""
-    return x / y
+    be = _backend(backend)
+    return be.b_sub(_as_backend_array(x, be), _as_backend_array(y, be))
 
 
-def b_mult(x, y):
+def b_mult(x, y, backend=None):
     """B-multiplication: x ⊗ y = x^y"""
-    return x ** y
+    be = _backend(backend)
+    return be.b_mul(_as_backend_array(x, be), _as_backend_array(y, be))
 
 
-def b_div(x, y, eps=1e-12):
-    x = np.asarray(x, dtype=float)
-    y = np.asarray(y, dtype=float)
-
-    x = np.maximum(x, eps)
-    y = np.where((y <= 0) | (np.isclose(y, 1.0)), eps, y)
-
-    return np.log(x) / np.log(y)
+def b_div(x, y, eps=1e-12, backend=None):
+    be = _backend(backend)
+    return be.b_div(_as_backend_array(x, be), _as_backend_array(y, be), eps=eps)
 
 
 
@@ -44,35 +101,36 @@ def b_div(x, y, eps=1e-12):
 #  B-DERIVATIVE
 # ============================================================
 
-def b_derivative(f, x, dx=1e-8):
+def b_derivative(f, x, dx=1e-8, eps=1e-30, backend=None):
     """
-    Computes D_B f(x) = exp( d/d(ln x) ln f(x) )
+    Computes D_B f(x) = exp( d/d(ln x) ln f(x) ) using the chosen backend.
 
     Uses finite differences:
         d/d(ln x) g = (g(x+dx) - g(x-dx)) / ( ln(x+dx) - ln(x-dx) )
     """
-    x = np.asarray(x)
+    be = _backend(backend)
+    x_arr = be.asarray(x)
 
-    # avoid hitting zero
-    xp = x + dx
-    xm = x - dx
-    xm = np.where(xm <= 0, x, xm)  # ensure positive
+    xp_arr = x_arr + dx
+    xm_arr = x_arr - dx
+    xm_arr = be.maximum(xm_arr, be.asarray(dx))  # ensure positive
 
-    g = lambda z: np.log(np.maximum(f(z), 1e-30)) #np.maximum(f(xs), 1e-30)
+    def _g(z):
+        return be.log(be.maximum(f(z), be.asarray(eps)))
 
-    num = g(xp) - g(xm)
-    den = np.log(xp) - np.log(xm)
+    num = _g(xp_arr) - _g(xm_arr)
+    den = be.log(xp_arr) - be.log(xm_arr)
 
-    return np.exp(num / den)
+    return be.exp(num / den)
 
 
 # ============================================================
 #  B-INTEGRAL (Continuous, Numeric Approximation)
 # ============================================================
 
-def b_integral(f, a, b, n=10000):
+def b_integral(f, a, b, n=10000, eps=1e-30, backend=None):
     """
-    Compute ∫ f(x) d_B x = exp( ∫ ln(f(x)) d(ln x) )
+    Compute ∫ f(x) d_B x = exp( ∫ ln(f(x)) d(ln x) ) using the active backend.
 
     Numeric approach:
         I = exp( sum ln(f(x_i)) * d(ln x_i) )
@@ -84,17 +142,17 @@ def b_integral(f, a, b, n=10000):
     """
     if a <= 0 or b <= 0:
         raise ValueError("B-integral domain requires a>0, b>0.")
-    
-    xs = np.linspace(a, b, n)
-    lnf = np.log(np.maximum(f(xs), 1e-30))
-    
-    dlnx = np.diff(np.log(xs))  # differences in ln(x)
-    
-    # midpoint rule: average ln(f) over intervals
+
+    be = _backend(backend)
+    xs = be.asarray(np.linspace(a, b, n))
+    lnf = be.log(be.maximum(f(xs), be.asarray(eps)))
+
+    lnxs = be.log(xs)
+    dlnx = lnxs[1:] - lnxs[:-1]
+
     mid = (lnf[1:] + lnf[:-1]) / 2
-    
-    I = np.exp(np.sum(mid * dlnx))
-    return I
+    total = (mid * dlnx).sum()
+    return be.exp(total)
 
 
 # ============================================================
@@ -149,77 +207,66 @@ def b_derivative_sympy(f, x):
 # ... your existing B-calculus code ...
 
 
-def log_gradient(field: np.ndarray, eps: float = 1e-12):
+def log_gradient(field, eps: float = 1e-12, backend=None):
     """
     Gradient of ln(field) using central differences with periodic-ish boundaries.
 
     Returns (gy, gx) arrays.
     """
-    f = np.maximum(field, eps)
-    logf = np.log(f)
-
-    gy = 0.5 * (np.roll(logf, -1, axis=0) - np.roll(logf, 1, axis=0))
-    gx = 0.5 * (np.roll(logf, -1, axis=1) - np.roll(logf, 1, axis=1))
-    return gy, gx
+    be = _backend(backend)
+    return be.log_gradient(_as_backend_array(field, be), eps=eps)
 
 
-def b_gradient(field: np.ndarray, eps: float = 1e-12):
+def b_gradient(field, eps: float = 1e-12, backend=None):
     """
     B-gradient: exp(grad ln(field)).
 
     Mostly for future use (forces, flows). For diffusion we mainly
     use log_gradient/log_laplacian.
     """
-    gy, gx = log_gradient(field, eps=eps)
-    return np.exp(gy), np.exp(gx)
+    be = _backend(backend)
+    gy, gx = log_gradient(field, eps=eps, backend=be)
+    return be.exp(gy), be.exp(gx)
 
 
-def log_laplacian(field: np.ndarray, eps: float = 1e-12):
+def log_laplacian(field, eps: float = 1e-12, backend=None):
     """
     Discrete Laplacian of ln(field) on a 2D grid with simple 5-point stencil.
 
     This is the main operator we use for B-diffusion.
     """
-    f = np.maximum(field, eps)
-    logf = np.log(f)
-
-    lap = (
-        -4.0 * logf
-        + np.roll(logf, 1, axis=0)
-        + np.roll(logf, -1, axis=0)
-        + np.roll(logf, 1, axis=1)
-        + np.roll(logf, -1, axis=1)
-    )
-    return lap
+    be = _backend(backend)
+    return be.log_laplacian(_as_backend_array(field, be), eps=eps)
 
 
-def b_laplacian(field: np.ndarray, eps: float = 1e-12):
+def b_laplacian(field, eps: float = 1e-12, backend=None):
     """
     B-Laplacian: exp(Δ ln(field)).
 
     This is a multiplicative analogue of the usual Laplacian.
     """
-    lap_log = log_laplacian(field, eps=eps)
-    return np.exp(lap_log)
+    be = _backend(backend)
+    lap_log = log_laplacian(field, eps=eps, backend=be)
+    return be.exp(lap_log)
 
 
-def divergence(Fy: np.ndarray, Fx: np.ndarray):
+def divergence(Fy, Fx, backend=None):
     """
     Divergence of a 2D vector field F = (Fy, Fx) using central differences
     with periodic-like boundaries.
     """
-    dFy_dy = 0.5 * (np.roll(Fy, -1, axis=0) - np.roll(Fy, 1, axis=0))
-    dFx_dx = 0.5 * (np.roll(Fx, -1, axis=1) - np.roll(Fx, 1, axis=1))
-    return dFy_dy + dFx_dx
+    be = _backend(backend)
+    return be.divergence(_as_backend_array(Fy, be), _as_backend_array(Fx, be))
 
 
-    #torch reworks
+# torch reworks
 
 def log_gradient_torch(field: torch.Tensor, eps: float = 1e-12):
     """
     Torch version of log_gradient.
     field: 2D tensor (H, W)
     """
+    import torch
     f = torch.clamp(field, min=eps)
     logf = torch.log(f)
 
@@ -229,11 +276,13 @@ def log_gradient_torch(field: torch.Tensor, eps: float = 1e-12):
 
 
 def b_gradient_torch(field: torch.Tensor, eps: float = 1e-12):
+    import torch
     gy, gx = log_gradient_torch(field, eps=eps)
     return torch.exp(gy), torch.exp(gx)
 
 
 def log_laplacian_torch(field: torch.Tensor, eps: float = 1e-12):
+    import torch
     f = torch.clamp(field, min=eps)
     logf = torch.log(f)
 
@@ -248,16 +297,23 @@ def log_laplacian_torch(field: torch.Tensor, eps: float = 1e-12):
 
 
 def b_laplacian_torch(field: torch.Tensor, eps: float = 1e-12):
+    import torch
     lap_log = log_laplacian_torch(field, eps=eps)
     return torch.exp(lap_log)
 
 
 def divergence_torch(Fy: torch.Tensor, Fx: torch.Tensor):
+    import torch
     dFy_dy = 0.5 * (torch.roll(Fy, -1, 0) - torch.roll(Fy, 1, 0))
     dFx_dx = 0.5 * (torch.roll(Fx, -1, 1) - torch.roll(Fx, 1, 1))
     return dFy_dy + dFx_dx
 
 __all__ = [
+    "NUMPY_BACKEND",
+    "TORCH_BACKEND",
+    "set_backend",
+    "BACKEND_NAME",
+    "xp",
     "b_add",
     "b_sub",
     "b_mult",
@@ -271,12 +327,10 @@ __all__ = [
     "b_gradient",
     "log_laplacian",
     "b_laplacian",
+    "divergence",
     "log_gradient_torch",
     "b_gradient_torch",
     "log_laplacian_torch",
     "b_laplacian_torch",
     "divergence_torch",
-    "b_laplacian",
-    "divergence",
-    "log_gradient_torch",
 ]


### PR DESCRIPTION
## Summary
- expose numpy and torch backend instances alongside a setter so callers can force a backend when needed
- update B-calculus derivative and integral utilities to operate through the active backend while keeping numpy and torch helpers available

## Testing
- python -m compileall engine

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343960990483208f16c801119a37b8)