### PR TITLE
Use backend arrays in energy tensor

### DIFF
--- a/engine/fields/energy_tensor.py
+++ b/engine/fields/energy_tensor.py
@@ -1,5 +1,4 @@
-import numpy as np
-from engine.math.b_calculus import log_laplacian
+from engine.math.b_calculus import log_laplacian, xp
 
 
 class EnergyTensor:
@@ -10,22 +9,28 @@ class EnergyTensor:
 
     def __init__(self, shape=(100, 100), initial_value: float = 0.0):
         self.shape = shape
-        self.grid = np.full(shape, initial_value, dtype=float)
+        if hasattr(xp, "full"):
+            self.grid = xp.full(shape, initial_value)
+        else:
+            self.grid = xp.asarray([[initial_value for _ in range(shape[1])] for _ in range(shape[0])])
 
     def ensure_nonnegative(self) -> None:
-        self.grid = np.maximum(self.grid, 0.0)
+        self.grid = xp.maximum(self.grid, xp.asarray(0.0))
 
     def add_energy(self, y: int, x: int, amount: float) -> None:
-        self.grid[y, x] += amount
+        self.grid[y, x] += xp.asarray(amount)
         self.ensure_nonnegative()
 
     def total_energy(self) -> float:
-        return float(self.grid.sum())
+        total = self.grid.sum()
+        return float(total.item() if hasattr(total, "item") else total)
 
     def b_diffuse(self, rate: float, dt: float) -> None:
         """
         B-diffusion for energy, analogous to mana.b_diffuse.
         """
         lap_log = log_laplacian(self.grid)
-        self.grid *= np.exp(rate * lap_log * dt)
+        rate_arr = xp.asarray(rate)
+        dt_arr = xp.asarray(dt)
+        self.grid *= xp.exp(rate_arr * lap_log * dt_arr)
         self.ensure_nonnegative()


### PR DESCRIPTION
## Summary
- initialize energy tensor grids with the selected backend
- ensure energy operations and diffusion use backend math for device/type parity

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69344961f37c832088ea2e854aeac1e2)