### PR TITLE
Make mana conversion backend-aware

### DIFF
--- a/engine/physics/mana_conversion.py
+++ b/engine/physics/mana_conversion.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Any, Sequence
 
-import numpy as np
+from engine.math.b_calculus import xp
 
 from .mana_phase import PhaseCode, PhaseProperties
 
 
 def apply_phase_conversions(
-    mana_grid: np.ndarray,
-    matter_grid: np.ndarray,
-    energy_grid: np.ndarray,
-    purity: np.ndarray,
-    phase: np.ndarray,
+    mana_grid: Any,
+    matter_grid: Any,
+    energy_grid: Any,
+    purity: Any,
+    phase: Any,
     phase_props: Sequence[PhaseProperties],
     dt: float,
 ) -> None:
@@ -29,6 +29,12 @@ def apply_phase_conversions(
       - mana_to_energy is proportional to local mana
       - for Purinium, matter annihilation also dumps energy.
     """
+    mana_grid = xp.asarray(mana_grid)
+    matter_grid = xp.asarray(matter_grid)
+    energy_grid = xp.asarray(energy_grid)
+    phase = xp.asarray(phase)
+    dt_arr = xp.asarray(dt)
+
     for code in PhaseCode:
         props = phase_props[int(code)]
 
@@ -36,26 +42,30 @@ def apply_phase_conversions(
         if props.matter_to_mana == 0.0 and props.mana_to_energy == 0.0:
             continue
 
-        mask = (phase == int(code))
-        if not np.any(mask):
+        mask = phase == xp.asarray(int(code))
+        has_phase = mask.any()
+        has_phase_bool = bool(has_phase.item() if hasattr(has_phase, "item") else has_phase)
+        if not has_phase_bool:
             continue
 
         if props.matter_to_mana != 0.0:
             # matter annihilation -> mana (and sometimes energy)
             available = matter_grid[mask]
-            converted = props.matter_to_mana * available * dt
-            matter_grid[mask] -= converted
-            mana_grid[mask] += converted
+            matter_to_mana = xp.asarray(props.matter_to_mana)
+            converted = matter_to_mana * available * dt_arr
+            matter_grid[mask] = matter_grid[mask] - converted
+            mana_grid[mask] = mana_grid[mask] + converted
 
             if code == PhaseCode.PURINIUM:
                 # Purinium dumps the converted rest-mass as mana-energy.
                 # (You can multiply by a big factor later if you want
                 #  more "star-like" behaviour.)
-                energy_grid[mask] += converted
+                energy_grid[mask] = energy_grid[mask] + converted
 
         if props.mana_to_energy != 0.0:
             # mana leaking into energy (radiation, heating, etc.)
             m_local = mana_grid[mask]
-            leaked = props.mana_to_energy * m_local * dt
-            mana_grid[mask] -= leaked
-            energy_grid[mask] += leaked
+            mana_to_energy = xp.asarray(props.mana_to_energy)
+            leaked = mana_to_energy * m_local * dt_arr
+            mana_grid[mask] = mana_grid[mask] - leaked
+            energy_grid[mask] = energy_grid[mask] + leaked


### PR DESCRIPTION
## Summary
- switch mana conversion to use the active numeric backend
- cast grids and parameters to backend arrays and use backend-safe checks
- keep arithmetic device/dtype consistent for mana, matter, and energy updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934522eea0c83209078fbf8366c9c93)