### PR TITLE
Use backend exp for mana growth factor

### DIFF
--- a/engine/rules/mana_rules.py
+++ b/engine/rules/mana_rules.py
@@ -1,6 +1,5 @@
-import numpy as np
 from engine.fields.mana_field import ManaField
-from engine.math.b_calculus import b_add  # using for scaling
+from engine.math.b_calculus import xp  # using for scaling
 
 
 
@@ -43,5 +42,5 @@ class BScaleManaGrowth(ManaRule):
 
     def apply(self, mana: ManaField, dt: float) -> None:
         # growth factor per time step:
-        factor = float(np.exp(self.k * dt))
+        factor = xp.exp(xp.asarray(self.k * dt))
         mana.b_scale_mult(factor)


### PR DESCRIPTION
## Summary
- compute the mana growth factor using the active numerical backend so it matches `mana.grid`
- ensure the growth multiplier passed into `b_scale_mult` is backend-native

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934578aed348320b69dfb7dfd7e8de3)