### PR TITLE
Use backend operations in mana field

### DIFF
--- a/engine/backends/backend.py
+++ b/engine/backends/backend.py
@@ -30,11 +30,20 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def full(self, shape: Any, fill_value: float) -> Any:
+    def full(self, shape: Any, fill_value: float, dtype=None) -> Any:
         """Create a backend-native array/tensor filled with ``fill_value``.
 
         Implementations should mirror ``numpy.full`` semantics while preserving
         the backend's preferred dtype and device placement.
+        """
+
+    @abstractmethod
+    def zeros(self, shape: Any, dtype=None) -> Any:
+        """Create a backend-native array/tensor of zeros.
+
+        Implementations should default to the backend's preferred dtype and
+        device but allow callers to override the dtype when necessary (e.g., to
+        store integer-coded phase labels).
         """
 
     @abstractmethod
@@ -147,4 +156,13 @@ class Backend(ABC):
         along the corresponding axes with periodic boundaries. Broadcasting of
         inputs should follow backend rules, and outputs must maintain the
         common dtype/device.
+        """
+
+    @abstractmethod
+    def laplacian(self, field: Any) -> Any:
+        """Compute the discrete 5-point Laplacian of ``field`` on a 2D grid.
+
+        The implementation must mirror NumPy/Torch semantics for indexing,
+        dtype, and device placement while using periodic boundaries via roll
+        operations.
         """

--- a/engine/backends/backend_example.py
+++ b/engine/backends/backend_example.py
@@ -11,6 +11,14 @@ class Backend(ABC):
         ...
 
     @abstractmethod
+    def full(self, shape, fill_value, dtype=None):
+        ...
+
+    @abstractmethod
+    def zeros(self, shape, dtype=None):
+        ...
+
+    @abstractmethod
     def log(self, x):
         ...
 
@@ -54,4 +62,8 @@ class Backend(ABC):
 
     @abstractmethod
     def divergence(self, Fy, Fx):
+        ...
+
+    @abstractmethod
+    def laplacian(self, field):
         ...

--- a/engine/backends/backends_numpy.py
+++ b/engine/backends/backends_numpy.py
@@ -12,8 +12,11 @@ class NumpyBackend(Backend):
     def asarray(self, x):
         return np.asarray(x, dtype=self.dtype)
 
-    def full(self, shape, fill_value):
-        return np.full(shape, fill_value, dtype=self.dtype)
+    def full(self, shape, fill_value, dtype=None):
+        return np.full(shape, fill_value, dtype=self.dtype if dtype is None else dtype)
+
+    def zeros(self, shape, dtype=None):
+        return np.zeros(shape, dtype=self.dtype if dtype is None else dtype)
 
     def log(self, x):
         return np.log(x)
@@ -68,3 +71,12 @@ class NumpyBackend(Backend):
         dFy_dy = 0.5 * (np.roll(Fy, -1, axis=0) - np.roll(Fy, 1, axis=0))
         dFx_dx = 0.5 * (np.roll(Fx, -1, axis=1) - np.roll(Fx, 1, axis=1))
         return dFy_dy + dFx_dx
+
+    def laplacian(self, field):
+        return (
+            -4.0 * field
+            + np.roll(field, 1, axis=0)
+            + np.roll(field, -1, axis=0)
+            + np.roll(field, 1, axis=1)
+            + np.roll(field, -1, axis=1)
+        )

--- a/engine/backends/backends_torch.py
+++ b/engine/backends/backends_torch.py
@@ -17,8 +17,11 @@ class TorchBackend(Backend):
     def asarray(self, x):
         return torch.as_tensor(x, device=self.device, dtype=self.dtype)
 
-    def full(self, shape, fill_value):
-        return torch.full(shape, fill_value, device=self.device, dtype=self.dtype)
+    def full(self, shape, fill_value, dtype=None):
+        return torch.full(shape, fill_value, device=self.device, dtype=self.dtype if dtype is None else dtype)
+
+    def zeros(self, shape, dtype=None):
+        return torch.zeros(shape, device=self.device, dtype=self.dtype if dtype is None else dtype)
 
     def log(self, x):
         return torch.log(x)
@@ -73,3 +76,12 @@ class TorchBackend(Backend):
         dFy_dy = 0.5 * (torch.roll(Fy, -1, 0) - torch.roll(Fy, 1, 0))
         dFx_dx = 0.5 * (torch.roll(Fx, -1, 1) - torch.roll(Fx, 1, 1))
         return dFy_dy + dFx_dx
+
+    def laplacian(self, field):
+        return (
+            -4.0 * field
+            + torch.roll(field, 1, 0)
+            + torch.roll(field, -1, 0)
+            + torch.roll(field, 1, 1)
+            + torch.roll(field, -1, 1)
+        )

--- a/engine/fields/mana_field.py
+++ b/engine/fields/mana_field.py
@@ -1,8 +1,14 @@
 import numpy as np
-from scipy.signal import convolve2d
-from engine.math.b_calculus import log_gradient, log_laplacian  # you already had log_laplacian
-from engine.math.b_calculus import divergence                  # NEW
-from engine.math.b_calculus import b_add, b_mult  # we’ll use these first
+
+from engine.math.b_calculus import (
+    b_add,
+    b_mult,
+    divergence,
+    get_backend,
+    laplacian,
+    log_gradient,
+    log_laplacian,
+)
 
 
 
@@ -11,29 +17,34 @@ class ManaField:
     Represents a mana density field on a 2D grid.
     """
     
-    _LAPLACIAN_KERNEL = np.array(
-        [[0.0, 1.0, 0.0],
-         [1.0, -4.0, 1.0],
-         [0.0, 1.0, 0.0]]
-    )
-    
     def __init__(self, shape=(100, 100), initial_value: float = 0.0):
         self.shape = shape
+        backend = get_backend()
         base = max(initial_value, 0.0)
-        self.grid = np.full(shape, base, dtype=float) + 1e-12
-    
+        self.grid = backend.full(shape, base) + backend.asarray(1e-12)
+
         # NEW: phase index per cell (will be managed by phase rules)
         # 0: particles, 1: energy, 2: gas, 3: refined, 4: aether, 5: purinium
-        self.phase = np.zeros(shape, dtype=np.uint8)   
+        phase_dtype = np.uint8
+        if backend.__class__.__name__ == "TorchBackend":
+            import torch
+
+            phase_dtype = torch.uint8
+
+        self.phase = backend.zeros(shape, dtype=phase_dtype)
     
     def add_mana(self, y: int, x: int, amount: float) -> None:
-        self.grid[y, x] += amount
-    
+        backend = get_backend()
+        self.grid[y, x] += backend.asarray(amount)
+
     def remove_mana(self, y: int, x: int, amount: float) -> None:
-        self.grid[y, x] = max(0.0, self.grid[y, x] - amount)
+        backend = get_backend()
+        updated = self.grid[y, x] - backend.asarray(amount)
+        self.grid[y, x] = backend.maximum(updated, backend.asarray(0.0))
     
     def total_mana(self) -> float:
-        return float(self.grid.sum())
+        total = self.grid.sum()
+        return float(total.item() if hasattr(total, "item") else total)
     
     def diffuse(self, rate: float, dt: float) -> None:
         """
@@ -43,8 +54,11 @@ class ManaField:
         This is VERY basic and not numerically perfect,
         but good for prototyping.
         """
-        lap = convolve2d(self.grid, self._LAPLACIAN_KERNEL, mode="same", boundary="symm")
-        self.grid += rate * dt * lap
+        backend = get_backend()
+        lap = laplacian(self.grid, backend=backend)
+        rate_arr = backend.asarray(rate)
+        dt_arr = backend.asarray(dt)
+        self.grid = self.grid + rate_arr * dt_arr * lap
     
     def b_diffuse(self, rate: float, dt: float) -> None:
         """
@@ -55,8 +69,11 @@ class ManaField:
         So in normal space:
             m_new = m * exp(rate * Δ log m * dt)
         """
-        lap_log = log_laplacian(self.grid)
-        self.grid *= np.exp(rate * lap_log * dt)
+        backend = get_backend()
+        lap_log = log_laplacian(self.grid, backend=backend)
+        rate_arr = backend.asarray(rate)
+        dt_arr = backend.asarray(dt)
+        self.grid = self.grid * backend.exp(rate_arr * lap_log * dt_arr)
         self.ensure_positive()
     
     def b_advect(self, strength: float, dt: float) -> None:
@@ -76,26 +93,30 @@ class ManaField:
             return
 
         # Use log-gradient so behaviour is multiplicative-scale aware
-        gy, gx = log_gradient(self.grid)
+        backend = get_backend()
+        gy, gx = log_gradient(self.grid, backend=backend)
 
         # Velocity field (you can flip the sign if you want flows from low→high)
-        vy = -strength * gy
-        vx = -strength * gx
+        strength_arr = backend.asarray(strength)
+        vy = -strength_arr * gy
+        vx = -strength_arr * gx
 
         # Flux = m * v
         Fy = self.grid * vy
         Fx = self.grid * vx
 
         # Divergence of the flux
-        divF = divergence(Fy, Fx)
+        divF = divergence(Fy, Fx, backend=backend)
 
         # Advection update
-        self.grid -= dt * divF
+        dt_arr = backend.asarray(dt)
+        self.grid = self.grid - dt_arr * divF
         self.ensure_positive()
     
     def copy(self) -> "ManaField":
         mf = ManaField(self.shape)
-        mf.grid = self.grid.copy()
+        mf.grid = self.grid.clone() if hasattr(self.grid, "clone") else self.grid.copy()
+        mf.phase = self.phase.clone() if hasattr(self.phase, "clone") else self.phase.copy()
         return mf
     
     def ensure_positive(self, eps: float = 1e-12) -> None:
@@ -103,7 +124,8 @@ class ManaField:
         Ensure that all mana values stay strictly positive
         (needed for B-calculus, which uses ln).
         """
-        self.grid = np.maximum(self.grid, eps)
+        backend = get_backend()
+        self.grid = backend.maximum(self.grid, backend.asarray(eps))
     
     def b_scale_mult(self, factor: float) -> None:
         """
@@ -114,7 +136,8 @@ class ManaField:
         Using your B-add definition.
         """
         self.ensure_positive()
-        self.grid = b_add(self.grid, factor)  # which is just self.grid * factor
+        backend = get_backend()
+        self.grid = b_add(self.grid, backend.asarray(factor))  # which is just self.grid * factor
     
     def b_scale_power(self, exponent: float) -> None:
         """
@@ -123,4 +146,5 @@ class ManaField:
             mana_new = mana ⊗ exponent = mana^exponent
         """
         self.ensure_positive()
-        self.grid = b_mult(self.grid, exponent)  # which is self.grid ** exponent
+        backend = get_backend()
+        self.grid = b_mult(self.grid, backend.asarray(exponent))  # which is self.grid ** exponent

--- a/engine/math/b_calculus.py
+++ b/engine/math/b_calculus.py
@@ -36,6 +36,12 @@ elif BACKEND_NAME == "numpy":
     NUMPY_BACKEND = xp
 
 
+def get_backend():
+    """Return the active backend instance (NumPy or Torch)."""
+
+    return xp
+
+
 def _backend(backend=None):
     if backend is None:
         return xp
@@ -239,6 +245,13 @@ def log_laplacian(field, eps: float = 1e-12, backend=None):
     return be.log_laplacian(_as_backend_array(field, be), eps=eps)
 
 
+def laplacian(field, backend=None):
+    """Discrete Laplacian of ``field`` on a 2D grid with periodic boundaries."""
+
+    be = _backend(backend)
+    return be.laplacian(_as_backend_array(field, be))
+
+
 def b_laplacian(field, eps: float = 1e-12, backend=None):
     """
     B-Laplacian: exp(Δ ln(field)).
@@ -312,6 +325,7 @@ __all__ = [
     "NUMPY_BACKEND",
     "TORCH_BACKEND",
     "set_backend",
+    "get_backend",
     "BACKEND_NAME",
     "xp",
     "b_add",
@@ -326,6 +340,7 @@ __all__ = [
     "log_gradient",
     "b_gradient",
     "log_laplacian",
+    "laplacian",
     "b_laplacian",
     "divergence",
     "log_gradient_torch",


### PR DESCRIPTION
## Summary
- update ManaField to initialize and mutate state using the active backend and backend-friendly Laplacian/advection ops
- extend backend interfaces with zeros and Laplacian helpers and expose the active backend accessor
- ensure B-scale helpers operate on backend tensors to preserve dtype/device

## Testing
- python -m pytest tests/test_phase_rules.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345787c644832093937a03b1c18451)