### PR TITLE
Add backend asnumpy conversions for plotting

### DIFF
--- a/engine/backends/backend.py
+++ b/engine/backends/backend.py
@@ -15,6 +15,16 @@ class Backend(ABC):
 
     # ---- basic array ops ----
     @abstractmethod
+    def asnumpy(self, x: Any) -> Any:
+        """Convert ``x`` to a NumPy ``ndarray`` on CPU.
+
+        Implementations should accept backend-native arrays/tensors or scalars
+        and return a NumPy array suitable for plotting/logging while preserving
+        values (and dtype when practical). Conversion should detach gradients
+        for autograd-enabled backends.
+        """
+
+    @abstractmethod
     def asarray(self, x: Any) -> Any:
         """Convert ``x`` to a backend-native floating array/tensor.
 

--- a/engine/backends/backends_numpy.py
+++ b/engine/backends/backends_numpy.py
@@ -9,6 +9,9 @@ class NumpyBackend(Backend):
         self.dtype = dtype
 
     # basic ops
+    def asnumpy(self, x):
+        return np.asarray(x, dtype=self.dtype)
+
     def asarray(self, x):
         return np.asarray(x, dtype=self.dtype)
 

--- a/engine/backends/backends_torch.py
+++ b/engine/backends/backends_torch.py
@@ -14,6 +14,9 @@ class TorchBackend(Backend):
         self.dtype = dtype
 
     # basic ops
+    def asnumpy(self, x):
+        return torch.as_tensor(x, device=self.device, dtype=self.dtype).detach().cpu().numpy()
+
     def asarray(self, x):
         return torch.as_tensor(x, device=self.device, dtype=self.dtype)
 


### PR DESCRIPTION
## Summary
- add `asnumpy` to the backend interface for consistent CPU array conversion
- implement NumPy and Torch conversions to support plotting/diagnostics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934432b38488320aaa6a9627dbfd8f9)