### PR TITLE
Ensure plotting normalization stays in NumPy

### DIFF
--- a/engine/utils/plotting.py
+++ b/engine/utils/plotting.py
@@ -5,24 +5,29 @@ import matplotlib.pyplot as plt
 from engine.math import b_calculus
 # ... existing plot_scalar_field here ...
 
+
+def _normalize_numpy(field_np: np.ndarray) -> np.ndarray:
+    """Normalize a NumPy array to 0..1 without leaving NumPy space."""
+
+    fmin = float(np.min(field_np))
+    fmax = float(np.max(field_np))
+    denom = fmax - fmin
+
+    if denom == 0:
+        return np.zeros_like(field_np, dtype=float)
+
+    return (field_np - fmin) / denom
+
+
 def plot_scalar_field(field: np.ndarray, title: str = "Field") -> None:
     """
     Quick 2D visualization for a scalar field.
     """
     be = b_calculus.get_backend()
-    # stay on NumPy after conversion so matplotlib never sees backend tensors
     field_np = np.asarray(be.asnumpy(field))
+    img = _normalize_numpy(field_np)
 
-    # normalize strictly in NumPy to avoid torch/cupy objects reaching matplotlib
-    fmin = float(np.min(field_np))
-    fmax = float(np.max(field_np))
-    denom = fmax - fmin
-    if denom == 0:
-        img = np.zeros_like(field_np, dtype=float)
-    else:
-        img = (field_np - fmin) / denom
-
-    plt.imshow(img, origin="lower", interpolation="nearest")
+    plt.imshow(np.asarray(img), origin="lower", interpolation="nearest")
     plt.colorbar(label="normalized value")
     plt.title(title)
     plt.tight_layout()
@@ -53,7 +58,7 @@ def plot_phase_map(phase: np.ndarray, title: str = "Mana phases") -> None:
     phase_np = np.asarray(be.asnumpy(phase))
 
     fig, ax = plt.subplots(figsize=(5, 5))
-    im = ax.imshow(phase_np, origin="lower", cmap=cmap, norm=norm)
+    im = ax.imshow(np.asarray(phase_np), origin="lower", cmap=cmap, norm=norm)
     ax.set_title(title)
 
     # make a tiny custom legend
@@ -82,7 +87,7 @@ def plot_purity_field(purity: np.ndarray, title: str = "Mana purity") -> None:
     purity_np = np.asarray(be.asnumpy(purity))
 
     fig, ax = plt.subplots(figsize=(5, 5))
-    im = ax.imshow(purity_np, origin="lower", vmin=0.0, vmax=1.0)
+    im = ax.imshow(np.asarray(purity_np), origin="lower", vmin=0.0, vmax=1.0)
     ax.set_title(title)
     cbar = plt.colorbar(im, ax=ax)
     cbar.set_label("purity (mana / (mana + matter))")


### PR DESCRIPTION
## Summary
- normalize scalar fields in pure NumPy after converting backend tensors
- ensure matplotlib always receives NumPy arrays for scalar, phase, and purity maps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346fcd8e9c8320a680f9cc547ffdb1)