### PR TITLE
Fix PhaseCode import in phase rules test

### DIFF
--- a/tests/test_phase_rules.py
+++ b/tests/test_phase_rules.py
@@ -56,7 +56,7 @@ if torch is not None and "scipy" not in sys.modules:
     sys.modules["scipy.signal"] = signal_stub
 
 from engine.rules.phase_rules import PhaseTransitionRule
-from engine.physics.mana_phase import PhaseCode
+from engine.metaphysics.mana_phase import PhaseCode
 
 
 @pytest.mark.skipif(torch is None, reason="torch backend not available")


### PR DESCRIPTION
## Summary
- update phase rules test to import PhaseCode from the metaphysics module used by PhaseTransitionRule
- ensure entropy feedback test continues to run against the corrected enum

## Testing
- pytest tests/test_phase_rules.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934712810b083209a3a26ef88b00fe1)